### PR TITLE
fix: do not launch the game after a failed install/uninstall

### DIFF
--- a/PriconneReTLInstaller/InstallerFunctions.cs
+++ b/PriconneReTLInstaller/InstallerFunctions.cs
@@ -711,7 +711,9 @@ namespace InstallerFunctions
                 }
                 ProcessFinish?.Invoke();
 
-                if (launch && !cancelledByUser)
+                // Only launch the game if the operation actually succeeded -- never launch a
+                // half-patched game and then exit, which would hide the failure from the user.
+                if (launch && !cancelledByUser && processSuccess)
                 {
                     bool result = false;
                     switch (Settings.Default.selectedLauncher)


### PR DESCRIPTION
ProcessOperation computes processSuccess (remove && download && extract) but launched the game in its finally regardless, then exited the app after ~5s -- so a failed/half-patched run would still launch the game and hide the error. Gate the launch on processSuccess so the game only starts when the operation actually succeeded.