### PR TITLE
security: harden XML deserialization against XXE

### DIFF
--- a/PriconneReTLInstaller/HelperFunctions.cs
+++ b/PriconneReTLInstaller/HelperFunctions.cs
@@ -495,7 +495,10 @@ namespace HelperFunctions
             var stringCollection = new StringCollection();
             var serializer = new XmlSerializer(stringCollection.GetType());
 
-            using (var reader = new XmlTextReader(new System.IO.StringReader(serializedValue)))
+            // Harden against XXE: disable DTD processing and external entity resolution
+            // (XmlTextReader resolves them by default). Imported settings are untrusted input.
+            var settings = new XmlReaderSettings { DtdProcessing = DtdProcessing.Prohibit, XmlResolver = null };
+            using (var reader = XmlReader.Create(new System.IO.StringReader(serializedValue), settings))
             {
                 if (serializer.CanDeserialize(reader))
                 {


### PR DESCRIPTION
DeserializeStringCollection read the serialized value with XmlTextReader, which resolves DTDs and external entities by default. Settings imported from a file are untrusted input, so a crafted entry could trigger an XXE. Read via XmlReader.Create with DtdProcessing=Prohibit and XmlResolver=null instead.